### PR TITLE
Add `lib.mkFlake`

### DIFF
--- a/doc/src/autowiring.md
+++ b/doc/src/autowiring.md
@@ -35,6 +35,27 @@ Each of these are wired to the corresponding flake output, as indicated in the b
 | `modules/flake-parts/foo.nix`             | `flakeModules.foo`                                          |
 | `overlays/foo.nix`                        | `overlays.foo`                                              |
 
+## flake-parts
+
+Autowiring is also provided if you use just flake-parts, via the `lib.mkFlake` function. In your top-level flake.nix, you only need to define your `outputs` as follows:
+
+```nix
+{
+  inputs = ...;
+  outputs = inputs:
+    inputs.nixos-unified.lib.mkFlake
+      { inherit inputs; root = ./.; };
+}
+```
+
+This will,
+
+- Auto-import flake-parts modules under either `./nix/modules/flake-parts` or `./modules/flake-parts` (whichever exists)
+- Use a sensible default for `systems` which can be overriden.
+- Pass `root` as top-level module args, as a non-recursive way of referring to the path of the flake (without needing `inputs.self`).
+
+See [srid/haskell-template's flake.nix](https://github.com/srid/haskell-template/blob/master/flake.nix) for a ready example.
+
 [^default]: This path could as well be `configurations/nixos/foo/default.nix`. Likewise for other output types.
 
 [^hm-pkgs]: Why `legacyPackages`? Because, creating a home-manager configuration [requires `pkgs`](https://github.com/srid/nixos-unified/blob/47a26bc9118d17500bbe0c4adb5ebc26f776cc36/nix/modules/flake-parts/lib.nix#L97). See <https://github.com/nix-community/home-manager/issues/3075>

--- a/flake.nix
+++ b/flake.nix
@@ -9,23 +9,24 @@
 
     # Like flake-parts mkFlake, but auto-imports modules/flake-parts, consistent with autowiring feature.
     #
-    # Looks under either nix/modules/flake-parts or modules/flake-parts for modules to import. `systems` is set to a default value.
+    # Looks under either nix/modules/flake-parts or modules/flake-parts for modules to import. `systems` is set to a default value. `root` is passed as top-level module args (as distinct from `inputs.self` the use of which can lead to infinite recursion).
     lib.mkFlake =
       { inputs
-      , src
+      , root
       , systems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
       }:
       inputs.flake-parts.lib.mkFlake { inherit inputs; } {
         inherit systems;
+        _module.args = { inherit root; };
         imports = with builtins;
-          if pathExists "${src}/nix/modules/flake-parts" then
+          if pathExists "${root}/nix/modules/flake-parts" then
             map
-              (fn: "${src}/nix/modules/flake-parts/${fn}")
-              (attrNames (readDir (src + /nix/modules/flake-parts)))
-          else if pathExists "${src}/modules/flake-parts.nix" then
+              (fn: "${root}/nix/modules/flake-parts/${fn}")
+              (attrNames (readDir (root + /nix/modules/flake-parts)))
+          else if pathExists "${root}/modules/flake-parts.nix" then
             map
-              (fn: "${src}/modules/flake-parts/${fn}")
-              (attrNames (readDir (src + /modules/flake-parts)))
+              (fn: "${root}/modules/flake-parts/${fn}")
+              (attrNames (readDir (root + /modules/flake-parts)))
           else
             throw "Neither modules/flake-parts nor nix/modules/flake-parts exist";
       };

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,20 @@
     # For backwards compat only
     flakeModule = flakeModules.default;
 
+    # Like flake-parts mkFlake, but auto-imports modules/flake-parts, consistent with autowiring feature.
+    lib.mkFlake =
+      { inputs
+      , src
+      , systems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
+      }:
+      inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+        inherit systems;
+        imports = with builtins;
+          map
+            (fn: "${src}/modules/flake-parts/${fn}")
+            (attrNames (readDir (src + /modules/flake-parts)));
+      };
+
     templates =
       let
         tmplPath = path: builtins.path { inherit path; filter = path: _: baseNameOf path != "test.sh"; };


### PR DESCRIPTION
Provide the nixos/nix-darwin/home-manager autowiring feature to flake-parts as well.