### PR TITLE
Add flake-parts `specialArgs` to `flake` argument of all modules

### DIFF
--- a/examples/home/flake.nix
+++ b/examples/home/flake.nix
@@ -10,24 +10,25 @@
   };
 
   outputs = inputs@{ self, ... }:
-    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+    let
+      specialArgs = { myUserName = "john"; };
+    in
+    inputs.flake-parts.lib.mkFlake { inherit inputs specialArgs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       imports = [
         inputs.nixos-unified.flakeModules.default
       ];
 
       perSystem = { pkgs, ... }:
-        let
-          myUserName = "john";
-        in
         {
           legacyPackages.homeConfigurations.${myUserName} =
             self.nixos-unified.lib.mkHomeConfiguration
               pkgs
-              ({ pkgs, ... }: {
+              ({ pkgs, flake, ... }:
+              {
                 imports = [ self.homeModules.default ];
-                home.username = myUserName;
-                home.homeDirectory = "/${if pkgs.stdenv.isDarwin then "Users" else "home"}/${myUserName}";
+                home.username = flake.myUserName;
+                home.homeDirectory = "/${if pkgs.stdenv.isDarwin then "Users" else "home"}/${flake.myUserName}";
                 home.stateVersion = "22.11";
               });
         };

--- a/examples/home/flake.nix
+++ b/examples/home/flake.nix
@@ -11,7 +11,8 @@
 
   outputs = inputs@{ self, ... }:
     let
-      specialArgs = { myUserName = "john"; };
+      myUserName = "john";
+      specialArgs = { inherit myUserName; };
     in
     inputs.flake-parts.lib.mkFlake { inherit inputs specialArgs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
@@ -25,12 +26,15 @@
             self.nixos-unified.lib.mkHomeConfiguration
               pkgs
               ({ pkgs, flake, ... }:
-              {
-                imports = [ self.homeModules.default ];
-                home.username = flake.myUserName;
-                home.homeDirectory = "/${if pkgs.stdenv.isDarwin then "Users" else "home"}/${flake.myUserName}";
-                home.stateVersion = "22.11";
-              });
+                let
+                  inherit (flake) myUserName;
+                in
+                {
+                  imports = [ self.homeModules.default ];
+                  home.username = myUserName;
+                  home.homeDirectory = "/${if pkgs.stdenv.isDarwin then "Users" else "home"}/${myUserName}";
+                  home.stateVersion = "22.11";
+                });
         };
 
       flake = {

--- a/examples/home/flake.nix
+++ b/examples/home/flake.nix
@@ -34,19 +34,19 @@
                       home.stateVersion = "22.11";
                     });
             };
+
+          flake = {
+            # All home-manager configurations are kept here.
+            homeModules.default = { pkgs, ... }: {
+              imports = [ ];
+              programs = {
+                git.enable = true;
+                starship.enable = true;
+                bash.enable = true;
+              };
+            };
+          };
         })
       ];
-
-      flake = {
-        # All home-manager configurations are kept here.
-        homeModules.default = { pkgs, ... }: {
-          imports = [ ];
-          programs = {
-            git.enable = true;
-            starship.enable = true;
-            bash.enable = true;
-          };
-        };
-      };
     };
 }

--- a/examples/linux/flake.nix
+++ b/examples/linux/flake.nix
@@ -22,28 +22,31 @@
           # Configurations for Linux (NixOS) machines
           nixosConfigurations."example1" =
             self.nixos-unified.lib.mkLinuxSystem
-              { home-manager = true; }{
-                nixpkgs.hostPlatform = "x86_64-linux";
-                imports = [
-                  # Your machine's configuration.nix goes here
-                  ({ pkgs, flake, ... }:
-                  {
-                    # TODO: Put your /etc/nixos/hardware-configuration.nix here
-                    boot.loader.grub.device = "nodev";
-                    fileSystems."/" = { device = "/dev/disk/by-label/nixos"; fsType = "btrfs"; };
-                    users.users.${flake.myUserName}.isNormalUser = true;
-                    system.stateVersion = "23.05";
-                  })
-                  # Setup home-manager in NixOS config
-                  ({ flake, ... }:
-                  {
-                    home-manager.users.${flake.myUserName} = {
-                      imports = [ self.homeModules.default ];
-                      home.stateVersion = "22.11";
-                    };
-                  })
-                ];
-              };
+              { home-manager = true; }
+              ({ flake, ... }:
+                let
+                  inherit (flake) myUserName;
+                in
+                {
+                  nixpkgs.hostPlatform = "x86_64-linux";
+                  imports = [
+                    # Your machine's configuration.nix goes here
+                    ({ pkgs, ... }: {
+                      # TODO: Put your /etc/nixos/hardware-configuration.nix here
+                      boot.loader.grub.device = "nodev";
+                      fileSystems."/" = { device = "/dev/disk/by-label/nixos"; fsType = "btrfs"; };
+                      users.users.${myUserName}.isNormalUser = true;
+                      system.stateVersion = "23.05";
+                    })
+                    # Setup home-manager in NixOS config
+                    {
+                      home-manager.users.${myUserName} = {
+                        imports = [ self.homeModules.default ];
+                        home.stateVersion = "22.11";
+                      };
+                    }
+                  ];
+                });
 
           # home-manager configuration goes here.
           homeModules.default = { pkgs, ... }: {

--- a/examples/macos/flake.nix
+++ b/examples/macos/flake.nix
@@ -26,30 +26,32 @@
             self.nixos-unified.lib.mkMacosSystem
               { home-manager = true; }
               ({ flake, ... }:
-              {
-                nixpkgs.hostPlatform = "aarch64-darwin";
-                imports = [
-                  # Your nix-darwin configuration goes here
-                  ({ pkgs, ... }: {
-                    # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
-                    users.users.${flake.myUserName}.home = "/Users/${flake.myUserName}";
+                let
+                  inherit (flake) myUserName;
+                in
+                {
+                  nixpkgs.hostPlatform = "aarch64-darwin";
+                  imports = [
+                    # Your nix-darwin configuration goes here
+                    ({ pkgs, ... }: {
+                      # https://github.com/nix-community/home-manager/issues/4026#issuecomment-1565487545
+                      users.users.${myUserName}.home = "/Users/${myUserName}";
 
-                    security.pam.enableSudoTouchIdAuth = true;
+                      security.pam.enableSudoTouchIdAuth = true;
 
-                    # Used for backwards compatibility, please read the changelog before changing.
-                    # $ darwin-rebuild changelog
-                    system.stateVersion = 4;
-                  })
-                  # Setup home-manager in nix-darwin config
-                  ({ flake, ... }:
-                  {
-                    home-manager.users.${flake.myUserName} = {
-                      imports = [ self.homeModules.default ];
-                      home.stateVersion = "22.11";
-                    };
-                  })
-                ];
-              });
+                      # Used for backwards compatibility, please read the changelog before changing.
+                      # $ darwin-rebuild changelog
+                      system.stateVersion = 4;
+                    })
+                    # Setup home-manager in nix-darwin config
+                    {
+                      home-manager.users.${myUserName} = {
+                        imports = [ self.homeModules.default ];
+                        home.stateVersion = "22.11";
+                      };
+                    }
+                  ];
+                });
 
           # home-manager configuration goes here.
           homeModules.default = { pkgs, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       { inputs
       , root
       , systems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
-      , specialArgs ? {}
+      , specialArgs ? { }
       }:
       inputs.flake-parts.lib.mkFlake { inherit inputs specialArgs; } {
         inherit systems;

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -2,7 +2,7 @@
 let
   specialArgsFor = rec {
     common = {
-      flake = { inherit self inputs config specialArgs; } // specialArgs;
+      flake = { inherit self inputs config; } // specialArgs;
     };
     nixos = common;
     darwin = common // {

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -1,8 +1,8 @@
-{ self, inputs, config, lib, ... }:
+{ self, inputs, config, lib, specialArgs, ... }:
 let
   specialArgsFor = rec {
     common = {
-      flake = { inherit self inputs config; };
+      flake = { inherit self inputs config specialArgs; };
     };
     nixos = common;
     darwin = common // {

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -2,7 +2,7 @@
 let
   specialArgsFor = rec {
     common = {
-      flake = { inherit self inputs config specialArgs; };
+      flake = { inherit self inputs config specialArgs; } // specialArgs;
     };
     nixos = common;
     darwin = common // {


### PR DESCRIPTION
This builds on #103. I realised that `specialArgs` passed into the `mkFlake` function is not accessible within `nixos-unified` otherwise. `specialArgs` will be an empty attribute set if it is not passed into the `flake-parts.lib.mkFlake` function, so it is always available as an argument for modules in `imports`.

I have tried this on my config, but not using `nixos-unified`. I'm not sure if there is a need to implement any test.

I think this feels like the most natural implementation to work with the rest of `nixos-unified`. Please let me know if any change is required.

```
flake = { inherit self inputs config specialArgs; };
```

An alternative which also makes sense to me.

```
flake = { inherit self inputs config; } // specialArgs;
```

EDIT: And there is also the 3rd option, which is adopted by [nixos](https://nixos.org/manual/nixos/stable/options#opt-_module.args), [nix-darwin](https://daiderd.com/nix-darwin/manual/index.html#opt-_module.args) and [home-manager](https://nix-community.github.io/home-manager/options.xhtml#opt-_module.args)

I have changed the PR to follow this.

```
flake = { inherit self inputs config specialArgs; } // specialArgs;
```