### PR TITLE
home-manager: Set homeDirectory default value

### DIFF
--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -3,8 +3,10 @@
 ## Unreleased
 
 - autoWiring of flake outputs & `mkFlake`
-- home-manager: More unique backup filenames (#97)
 - activate script: add `--dry-run` (#104)
+- home-manager
+  - More unique backup filenames (#97)
+  - Add a default `home.homeDirectory` based on the user's username (#117)
 
 ## 0.2.0 (2024-10-03)
 

--- a/examples/home/flake.nix
+++ b/examples/home/flake.nix
@@ -27,7 +27,6 @@
               ({ pkgs, ... }: {
                 imports = [ self.homeModules.default ];
                 home.username = myUserName;
-                home.homeDirectory = "/${if pkgs.stdenv.isDarwin then "Users" else "home"}/${myUserName}";
                 home.stateVersion = "22.11";
               });
         };

--- a/nix/modules/flake-parts/lib.nix
+++ b/nix/modules/flake-parts/lib.nix
@@ -19,6 +19,7 @@ let
           home-manager.useGlobalPkgs = true;
           home-manager.useUserPackages = true;
           home-manager.extraSpecialArgs = specialArgsFor.nixos;
+          home-manager.sharedModules = [ homeModules.common ];
         }
       ];
     };
@@ -37,7 +38,11 @@ let
   };
 
   homeModules = {
-    common = { pkgs, ... }: {
+    common = { config, pkgs, ... }: {
+      # Sensible default for `home.homeDirectory`
+      home.homeDirectory = lib.mkDefault "/${if pkgs.stdenv.isDarwin then "Users" else "home"}/${config.home.username}";
+
+      # For macOS, $PATH must contain these.
       home.sessionPath = lib.mkIf pkgs.stdenv.isDarwin [
         "/etc/profiles/per-user/$USER/bin" # To access home-manager binaries
         "/nix/var/nix/profiles/system/sw/bin" # To access nix-darwin binaries


### PR DESCRIPTION
So the user doesn't have to set them themselves.