### PR TITLE
Update for nix flake update

### DIFF
--- a/doc/src/history.md
+++ b/doc/src/history.md
@@ -7,6 +7,7 @@
 - home-manager
   - More unique backup filenames (#97)
   - Add a default `home.homeDirectory` based on the user's username (#117)
+- Remove use of deprecated alias `--update-input` of `nix flake update`
 
 ## 0.2.0 (2024-10-03)
 

--- a/nix/modules/flake-parts/packages.nix
+++ b/nix/modules/flake-parts/packages.nix
@@ -30,7 +30,7 @@ in
           name = "update-main-flake-inputs";
           meta.description = "Update the primary flake inputs";
           text = ''
-            nix flake lock ${lib.foldl' (acc: x: acc + " --update-input " + x) "" inputs}
+            nix flake update${lib.foldl' (acc: x: acc + " " + x) "" inputs}
           '';
         };
 


### PR DESCRIPTION
Resolves 

```
nix run .#update
error: `nix flake lock --update-input nixpkgs` has been replaced by `nix flake update nixpkgs`
Try 'nix --help' for more information.
error: Recipe `update` failed on line 10 with exit code 1
```

