### PR TITLE
Fix nix copy command for legacy NixOS systems

### DIFF
--- a/activate/activate.nu
+++ b/activate/activate.nu
@@ -114,6 +114,6 @@ def activate_system_remote_ssh [ hostData: record, --dry-run=false ] {
 }
 
 def nix_copy [ src: string dst: string ] {
-    log info $"(ansi blue_bold)>>>(ansi reset) nix copy ($src) --to ($dst)"
-    nix copy $src --to $dst
+    log info $"(ansi blue_bold)>>>(ansi reset) nix --extra-experimental-features \"nix-command flakes\" copy ($src) --to ($dst)"
+    nix --extra-experimental-features "nix-command flakes" copy $src --to $dst
 }


### PR DESCRIPTION
## Summary
- Fixed `nix copy` command to include `--extra-experimental-features "nix-command flakes"`
- Prevents errors when deploying to legacy NixOS systems that don't have these experimental features enabled by default
- Updated both the actual command and the log message to be consistent

## Test plan
- [ ] Test deployment to a legacy NixOS system without experimental features enabled
- [ ] Verify the nix copy command now works without errors
- [ ] Confirm remote activation still functions correctly

🤖 Generated with [Claude Code](https://claude.ai/code)